### PR TITLE
upgrade to pg 9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # PostgreSQL service with pghashlib and PL-Proxy
 
-FROM postgres:9.4
+FROM postgres:9.6
 
 MAINTAINER Dimagi <devops@dimagi.com>
 


### PR DESCRIPTION
@snopoke @millerdev 
Now that all envs are on 9.6 i think its time to upgrade our travis builds. Is this all that is necessary to do that?