### PR TITLE
using postgres10 version as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # PostgreSQL service with pghashlib and PL-Proxy
 
-FROM postgres:12
+FROM postgres:10.17
 
 MAINTAINER Dimagi <devops@dimagi.com>
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12770

We are downgrading the Postgres version to 10 from the 12 version (master branch). In that process, we are planning a build a docker image of the postgres10 version. 