### PR TITLE
Update latest tag (on docker hub) to point to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # PostgreSQL service with pghashlib and PL-Proxy
 
-FROM postgres:14.3
+FROM postgres:18.3
 
 MAINTAINER Dimagi <devops@dimagi.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM postgres:18.3
 
-MAINTAINER Dimagi <devops@dimagi.com>
+LABEL maintainer="Dimagi <devops@dimagi.com>"
 
 RUN apt-get update && apt-get -y install --no-upgrade \
     gcc \


### PR DESCRIPTION
Part of https://dimagi.atlassian.net/browse/SAAS-19448

Followed the instructions in the readme to update the version of postgres here. Included fixing a deprecated warning as mentioned in the relevant commit.